### PR TITLE
Feat/psw 33 connect upload receipt page to s3 bucket

### DIFF
--- a/Apps/pisowise-be/controllers/receipt_controller.py
+++ b/Apps/pisowise-be/controllers/receipt_controller.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Depends, Query, HTTPException, File, UploadFile
+from models.receipt import UploadResponse
 from sqlalchemy.orm import Session
 from typing import List, Optional
 from models.receipt import ReceiptCreate, ReceiptUpdate, ReceiptResponse
@@ -7,13 +8,16 @@ from db.database import get_db
 
 receipt_router = APIRouter()
 
-@receipt_router.post("/receipts/upload-image", response_model=dict)
+@receipt_router.post("/receipts/upload-image", response_model=UploadResponse)
 async def upload_receipt_image(
     file: UploadFile = File(...),
+    project_id: str = Query(..., description="Project ID to associate with the receipt"),  # Required
+    create_receipt: bool = Query(False, description="Whether to create a receipt record with the uploaded image"),  # Required
     db: Session = Depends(get_db)
 ):
     uc = ReceiptUseCase(db)
-    return await uc.upload_receipt_image_usecase(file)
+    result = await uc.upload_receipt_image_usecase(file, project_id, create_receipt)
+    return result
 
 @receipt_router.post("/receipts", response_model=ReceiptResponse)
 def create_receipt(receipt: ReceiptCreate, db: Session = Depends(get_db)):

--- a/Apps/pisowise-be/controllers/receipt_controller.py
+++ b/Apps/pisowise-be/controllers/receipt_controller.py
@@ -12,11 +12,10 @@ receipt_router = APIRouter()
 async def upload_receipt_image(
     file: UploadFile = File(...),
     project_id: str = Query(..., description="Project ID to associate with the receipt"),  # Required
-    create_receipt: bool = Query(False, description="Whether to create a receipt record with the uploaded image"),  # Required
     db: Session = Depends(get_db)
 ):
     uc = ReceiptUseCase(db)
-    result = await uc.upload_receipt_image_usecase(file, project_id, create_receipt)
+    result = await uc.upload_receipt_image_usecase(file, project_id)
     return result
 
 @receipt_router.post("/receipts", response_model=ReceiptResponse)

--- a/Apps/pisowise-be/controllers/receipt_controller.py
+++ b/Apps/pisowise-be/controllers/receipt_controller.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Query, HTTPException, File, UploadFile
+from fastapi import APIRouter, Depends, Query, HTTPException, File, UploadFile, Form
 from models.receipt import UploadResponse
 from sqlalchemy.orm import Session
 from typing import List, Optional
@@ -11,7 +11,7 @@ receipt_router = APIRouter()
 @receipt_router.post("/receipts/upload-image", response_model=UploadResponse)
 async def upload_receipt_image(
     file: UploadFile = File(...),
-    project_id: str = Query(..., description="Project ID to associate with the receipt"),  # Required
+    project_id: str = Form(..., description="Project ID to associate with the receipt"),  # Required
     db: Session = Depends(get_db)
 ):
     uc = ReceiptUseCase(db)

--- a/Apps/pisowise-be/models/receipt.py
+++ b/Apps/pisowise-be/models/receipt.py
@@ -26,3 +26,6 @@ class ReceiptResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+class UploadResponse(BaseModel):
+   receipt: Optional[ReceiptResponse] = None

--- a/Apps/pisowise-be/models/receipt.py
+++ b/Apps/pisowise-be/models/receipt.py
@@ -29,4 +29,3 @@ class ReceiptResponse(BaseModel):
 
 class UploadResponse(BaseModel):
    image_url: str
-   receipt: Optional[ReceiptResponse] = None

--- a/Apps/pisowise-be/models/receipt.py
+++ b/Apps/pisowise-be/models/receipt.py
@@ -28,4 +28,5 @@ class ReceiptResponse(BaseModel):
         from_attributes = True
 
 class UploadResponse(BaseModel):
+   image_url: str
    receipt: Optional[ReceiptResponse] = None

--- a/Apps/pisowise-be/repositories/s3_repository.py
+++ b/Apps/pisowise-be/repositories/s3_repository.py
@@ -7,20 +7,6 @@ load_dotenv()
 
 class S3Repository:
     def __init__(self):
-        print("Initializing S3Repository")
-        print(f"- AWS_REGION: {os.getenv('AWS_REGION')}")
-        print(f"- S3_BUCKET_NAME: {os.getenv('S3_BUCKET_NAME')}")
-
-        # for debugging purposes
-        if not os.getenv('AWS_ACCESS_KEY_ID'):
-            print("WARNING: AWS_ACCESS_KEY_ID is not set")
-        if not os.getenv('AWS_SECRET_ACCESS_KEY'):
-            print("WARNING: AWS_SECRET_ACCESS_KEY is not set")
-        if not os.getenv('AWS_REGION'):
-            print("WARNING: AWS_REGION is not set")
-        if not os.getenv('S3_BUCKET_NAME'):
-            print("WARNING: S3_BUCKET_NAME is not set")
-
         self.s3_client = boto3.client(
             's3',
             aws_access_key_id=os.getenv('AWS_ACCESS_KEY_ID'),
@@ -29,32 +15,28 @@ class S3Repository:
         )
         self.bucket_name = os.getenv('S3_BUCKET_NAME')
 
-    async def upload_file(self, file_content: bytes, key: str, content_type: str) -> str:
+    async def upload_file(self, file_content: bytes, key: str, content_type: str, project_id: str = None) -> str:
         try:
-            
-            if file_content is None:
+            if not file_content:
                 raise ValueError("file_content cannot be None")
             if not key:
                 raise ValueError("key cannot be empty")
             if not content_type:
-                content_type = "application/octet-stream"  
-                
-            # for debugging purposes
-            print(f"Uploading file with key: {key}, content_type: {content_type}, bucket: {self.bucket_name}")
+                content_type = "application/octet-stream"
+
+            metadata = {"project_id": project_id} if project_id else {}
 
             self.s3_client.put_object(
                 Body=file_content,
                 Bucket=self.bucket_name,
                 Key=key,
-                ContentType=content_type
+                ContentType=content_type,
+                Metadata=metadata
             )
 
-            
-            url = f"https://{self.bucket_name}.s3.{os.getenv('AWS_REGION')}.amazonaws.com/{key}"
-            return url
+            return f"https://{self.bucket_name}.s3.{os.getenv('AWS_REGION')}.amazonaws.com/{key}"
 
         except Exception as e:
-            print(f"Error in upload_file: {str(e)}")
             raise Exception(f"S3 upload error: {str(e)}")
         
     async def delete_file(self, key: str) -> bool:

--- a/Apps/pisowise-be/repositories/s3_repository.py
+++ b/Apps/pisowise-be/repositories/s3_repository.py
@@ -31,7 +31,7 @@ class S3Repository:
                 Bucket=self.bucket_name,
                 Key=key,
                 ContentType=content_type,
-                Metadata=metadata
+                Metadata=metadata,
             )
 
             return f"https://{self.bucket_name}.s3.{os.getenv('AWS_REGION')}.amazonaws.com/{key}"

--- a/Apps/pisowise-be/usecases/receipt_usecase.py
+++ b/Apps/pisowise-be/usecases/receipt_usecase.py
@@ -1,12 +1,12 @@
+import datetime
 from fastapi import HTTPException, UploadFile
 from sqlalchemy.orm import Session
 import os
 import uuid
 from repositories.receipt_repository import ReceiptRepository
 from repositories.s3_repository import S3Repository
-from models.base import Receipt
 from models.receipt import ReceiptCreate, ReceiptUpdate, ReceiptResponse
-from typing import List, Dict
+from typing import List, Dict, Union
 
 class ReceiptUseCase:
     def __init__(self, db: Session):
@@ -16,64 +16,75 @@ class ReceiptUseCase:
     def create_receipt_usecase(self, receipt: ReceiptCreate) -> ReceiptResponse:
         return self.repo.create_receipt(receipt)
 
-    def get_all_receipts_usecase(self) -> List[Receipt]:
+    def get_all_receipts_usecase(self) -> List[ReceiptResponse]:
         return self.repo.get_all_receipts()
 
-    def get_receipts_by_project_id_usecase(self, project_id: str) -> List[Receipt]:
-        receipt = self.repo.get_receipts_by_project_id(project_id)
-        if not receipt:
+    def get_receipts_by_project_id_usecase(self, project_id: str) -> List[ReceiptResponse]:
+        receipts = self.repo.get_receipts_by_project_id(project_id)
+        if not receipts:
             raise HTTPException(status_code=404, detail="No receipts found for this project")
+        return receipts
 
-        return receipt
-
-    def get_receipt_by_id_usecase(self, receipt_id: str) -> Receipt:
+    def get_receipt_by_id_usecase(self, receipt_id: str) -> ReceiptResponse:
         if not receipt_id:
-            raise HTTPException(status_code=400, detail="Receipt id is required")
-
+            raise HTTPException(status_code=400, detail="Receipt ID is required")
         receipt = self.repo.get_receipt_by_id(receipt_id)
         if not receipt:
-            raise HTTPException(status_code=404, detail="No receipt found with this id")
-
+            raise HTTPException(status_code=404, detail="No receipt found with this ID")
         return receipt
 
-    def update_receipt_usecase(
-        self, receipt_id: str, updates: ReceiptUpdate
-    ) -> ReceiptResponse:
+    def update_receipt_usecase(self, receipt_id: str, updates: ReceiptUpdate) -> ReceiptResponse:
         return self.repo.update_receipt(receipt_id, updates)
 
     def delete_receipt_usecase(self, receipt_id: str) -> bool:
-        
         receipt = self.repo.get_receipt_by_id(receipt_id)
         if receipt and receipt.image_url:
-            
             try:
-                
                 key = receipt.image_url.split('.com/')[1]
-                
                 self.s3_repo.delete_file(key)
             except Exception:
-                
                 pass
-                
         return self.repo.delete_receipt(receipt_id)
-        
-    async def upload_receipt_image_usecase(self, file: UploadFile) -> Dict[str, str]:
+
+    async def upload_receipt_image_usecase(
+        self, 
+        file: UploadFile, 
+        project_id: str, 
+        create_receipt: bool = False
+    ) -> Dict[str, Union[str, ReceiptResponse]]:
         try:
+            if not file:
+                raise HTTPException(status_code=400, detail="No file provided")
             file_content = await file.read()
+            if not file_content:
+                raise HTTPException(status_code=400, detail="File is empty")
 
+            # Generate unique file ID and S3 key
             file_id = str(uuid.uuid4())
-
-            file_extension = os.path.splitext(file.filename)[1]
-
+            file_extension = os.path.splitext(file.filename)[1] if file.filename else ".jpg"
             s3_key = f"receipts/{file_id}{file_extension}"
 
             image_url = await self.s3_repo.upload_file(
                 file_content=file_content,
                 key=s3_key,
-                content_type=file.content_type
+                content_type=file.content_type or "application/octet-stream",
+                project_id=project_id
             )
 
-            return {"image_url": image_url}
+            # Optionally create a receipt
+            result = {"image_url": image_url}
+            if create_receipt:
+                receipt_data = ReceiptCreate(
+                    project_id=project_id,
+                    total_amount=0.0,
+                    transaction_date=datetime.datetime.now().date(),
+                    vendor_name=None,
+                    image_url=image_url
+                )
+                receipt = self.repo.create_receipt(receipt_data)
+                result["receipt"] = receipt
+
+            return result
 
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Image upload failed: {str(e)}")

--- a/Apps/pisowise-be/usecases/receipt_usecase.py
+++ b/Apps/pisowise-be/usecases/receipt_usecase.py
@@ -71,7 +71,6 @@ class ReceiptUseCase:
                 project_id=project_id
             )
 
-            # Optionally create a receipt
             result = {"image_url": image_url}
             if create_receipt:
                 receipt_data = ReceiptCreate(
@@ -82,7 +81,8 @@ class ReceiptUseCase:
                     image_url=image_url
                 )
                 receipt = self.repo.create_receipt(receipt_data)
-                result["receipt"] = receipt
+                if receipt:
+                    result["receipt"] = receipt
 
             return result
 

--- a/Apps/pisowise-be/usecases/receipt_usecase.py
+++ b/Apps/pisowise-be/usecases/receipt_usecase.py
@@ -50,7 +50,6 @@ class ReceiptUseCase:
         self, 
         file: UploadFile, 
         project_id: str, 
-        create_receipt: bool = False
     ) -> Dict[str, Union[str, ReceiptResponse]]:
         try:
             if not file:

--- a/Apps/pisowise-be/usecases/receipt_usecase.py
+++ b/Apps/pisowise-be/usecases/receipt_usecase.py
@@ -70,21 +70,7 @@ class ReceiptUseCase:
                 content_type=file.content_type or "application/octet-stream",
                 project_id=project_id
             )
-
-            result = {"image_url": image_url}
-            if create_receipt:
-                receipt_data = ReceiptCreate(
-                    project_id=project_id,
-                    total_amount=0.0,
-                    transaction_date=datetime.datetime.now().date(),
-                    vendor_name=None,
-                    image_url=image_url
-                )
-                receipt = self.repo.create_receipt(receipt_data)
-                if receipt:
-                    result["receipt"] = receipt
-
-            return result
+            return {"image_url": image_url}
 
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Image upload failed: {str(e)}")

--- a/Apps/pisowise-fe/app/projects/[id]/page.tsx
+++ b/Apps/pisowise-fe/app/projects/[id]/page.tsx
@@ -103,7 +103,7 @@ export default function ProjectDetailsPage() {
       ) : isManualReceiptButtonPressed ? (
         <ManualAddReceipt />
       ) : (
-        <AddReceipt />
+        <AddReceipt project_id={project.project_id} />
       )}
     </div>
   );

--- a/Apps/pisowise-fe/app/store/project/receipt-store.ts
+++ b/Apps/pisowise-fe/app/store/project/receipt-store.ts
@@ -43,7 +43,9 @@ interface ReceiptState {
   receipt: Receipt | null;
   receipts: Receipt[] | null;
   isLoading: boolean;
+  isUploading: boolean;
   error: string | null;
+  uploadError: string | null;
   getReceiptById: (receiptId: string) => Promise<void>;
   updateReceipt: (
     receiptId: string,
@@ -52,23 +54,117 @@ interface ReceiptState {
   deleteReceipt: (receiptId: string) => Promise<void>;
   getReceiptsByProjectId: (projectId: string) => Promise<Receipt[] | null>;
   createReceipt: (receiptData: CreateReceiptData) => Promise<Receipt | null>;
+  uploadImage: (file: File, projectId: string) => Promise<string | null>;
+  uploadReceiptWithImage: (
+    file: File,
+    projectId: string,
+  ) => Promise<Receipt | null>;
+  clearErrors: () => void;
 }
 
 const API_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
-export const useReceiptStore = create<ReceiptState>((set) => ({
+export const useReceiptStore = create<ReceiptState>((set, get) => ({
   receipt: null,
   receipts: null,
   isLoading: false,
+  isUploading: false,
   error: null,
+  uploadError: null,
+  clearErrors: () => {
+    set({ error: null, uploadError: null });
+  },
+  uploadImage: async (file: File, projectId: string) => {
+    try {
+      set({ isUploading: true, uploadError: null });
+      const formData = new FormData();
+      formData.append("file", file);
+      formData.append("project_id", projectId);
 
+      const response = await axios.post(
+        `${API_URL}/receipts/upload-image`,
+        formData,
+      );
+      set({ isUploading: false });
+      return response.data.image_url;
+    } catch (error: unknown) {
+      let errorMessage = "Failed to upload the image. Please try again.";
+      if (axios.isAxiosError(error)) {
+        errorMessage = error.response?.data?.message || error.message;
+      } else if (error instanceof Error) {
+        errorMessage = error.message;
+      }
+      set({
+        uploadError: errorMessage,
+        isUploading: false,
+      });
+      toast.error("Image upload failed", {
+        description: errorMessage,
+        style: { backgroundColor: "#E73648", color: "white" },
+      });
+      console.error(
+        "Image upload failed:",
+        axios.isAxiosError(error) ? error.response?.data : error,
+      );
+      return null;
+    }
+  },
+  uploadReceiptWithImage: async (file: File, projectId: string) => {
+    try {
+      set({ isUploading: true, uploadError: null });
+
+      const imageUrl = await get().uploadImage(file, projectId);
+      if (!imageUrl) {
+        set({ isUploading: false });
+        return null;
+      }
+      const receiptData = {
+        project_id: projectId,
+        total_amount: 0.0,
+        transaction_date: "2023-01-01", // Replace this with the extracted date from the receipt
+        vendor_name: "Vendor Name", // Replace with extracted vendor name
+        image_url: imageUrl,
+        items: [],
+      };
+      const newReceipt = await get().createReceipt(receiptData);
+      set({ isUploading: false });
+      if (newReceipt) {
+        toast.success("Receipt uploaded successfully", {
+          description: "Your receipt has been processed and saved.",
+          style: { backgroundColor: "#349868", color: "white" },
+        });
+      }
+      return newReceipt;
+    } catch (error: unknown) {
+      let errorMessage = "An unexpected error occurred. Please try again.";
+      if (axios.isAxiosError(error)) {
+        errorMessage =
+          error.response?.data?.message ||
+          "An error occurred while processing your request. Please try again.";
+      } else if (error instanceof Error) {
+        errorMessage = error.message;
+      }
+      set({
+        uploadError: errorMessage,
+        isUploading: false,
+      });
+      toast.error("Upload failed", {
+        description: errorMessage,
+        style: { backgroundColor: "#E73648", color: "white" },
+      });
+      console.error(
+        "Receipt upload failed:",
+        axios.isAxiosError(error) ? error.response?.data : error,
+      );
+      return null;
+    }
+  },
   getReceiptById: async (receiptId: string) => {
     try {
       set({ isLoading: true, error: null });
       const headers = await useAuthStore.getState().getAuthHeaders();
       const url = `${API_URL}/receipts/${receiptId}`;
       const response = await axios.get(url, { headers });
-
       set({ receipt: response.data, isLoading: false });
     } catch (error) {
       let errorMessage = "Failed to fetch receipt";
@@ -77,7 +173,6 @@ export const useReceiptStore = create<ReceiptState>((set) => ({
       } else if (error instanceof Error) {
         errorMessage = error.message;
       }
-
       set({
         error: errorMessage,
         isLoading: false,
@@ -89,19 +184,16 @@ export const useReceiptStore = create<ReceiptState>((set) => ({
       });
     }
   },
-
   createReceipt: async (receiptData: CreateReceiptData) => {
     try {
       set({ isLoading: true, error: null });
       const headers = await useAuthStore.getState().getAuthHeaders();
       const { items, ...receiptOnlyData } = receiptData;
-
       const receiptUrl = `${API_URL}/receipts`;
       const receiptResponse = await axios.post(receiptUrl, receiptOnlyData, {
         headers,
       });
       const newReceipt = receiptResponse.data;
-
       if (items && items.length > 0) {
         const itemPromises = items.map(async (item) => {
           const itemData: ItemCreate = {
@@ -119,7 +211,6 @@ export const useReceiptStore = create<ReceiptState>((set) => ({
         });
         await Promise.allSettled(itemPromises);
       }
-
       set((state) => ({
         receipt: newReceipt,
         receipts: state.receipts
@@ -127,7 +218,6 @@ export const useReceiptStore = create<ReceiptState>((set) => ({
           : [newReceipt],
         isLoading: false,
       }));
-
       toast.success("Receipt created successfully", {
         description: `Receipt from "${receiptData.vendor_name}" has been added to your project.`,
         style: { backgroundColor: "#349868", color: "white" },
@@ -140,7 +230,6 @@ export const useReceiptStore = create<ReceiptState>((set) => ({
       } else if (error instanceof Error) {
         errorMessage = error.message;
       }
-
       set({
         error: errorMessage,
         isLoading: false,
@@ -152,14 +241,12 @@ export const useReceiptStore = create<ReceiptState>((set) => ({
       return null;
     }
   },
-
   updateReceipt: async (receiptId: string, updates: Partial<Receipt>) => {
     try {
       set({ isLoading: true, error: null });
       const headers = await useAuthStore.getState().getAuthHeaders();
       const url = `${API_URL}/receipts/${receiptId}`;
       const response = await axios.put(url, updates, { headers });
-
       set({ receipt: response.data, isLoading: false });
       toast.success("Receipt updated successfully", {
         description: "Your receipt changes have been saved.",
@@ -172,7 +259,6 @@ export const useReceiptStore = create<ReceiptState>((set) => ({
       } else if (error instanceof Error) {
         errorMessage = error.message;
       }
-
       set({
         error: errorMessage,
         isLoading: false,
@@ -183,7 +269,6 @@ export const useReceiptStore = create<ReceiptState>((set) => ({
       });
     }
   },
-
   deleteReceipt: async (receiptId: string) => {
     try {
       set({ isLoading: true, error: null });
@@ -193,13 +278,11 @@ export const useReceiptStore = create<ReceiptState>((set) => ({
       };
       const url = `${API_URL}/receipts/${receiptId}`;
       await axios.delete(url, { headers });
-
       set((state) => ({
         receipts:
           state.receipts?.filter((r) => r.receipt_id !== receiptId) || [],
         isLoading: false,
       }));
-
       toast.success("Receipt deleted successfully", {
         description:
           "The receipt has been permanently removed from your project.",
@@ -212,7 +295,6 @@ export const useReceiptStore = create<ReceiptState>((set) => ({
       } else if (error instanceof Error) {
         errorMessage = error.message;
       }
-
       set({ error: errorMessage, isLoading: false });
       toast.error("Failed to delete receipt", {
         description: errorMessage,
@@ -220,7 +302,6 @@ export const useReceiptStore = create<ReceiptState>((set) => ({
       });
     }
   },
-
   getReceiptsByProjectId: async (projectId: string) => {
     try {
       set({ isLoading: true, error: null });
@@ -228,7 +309,6 @@ export const useReceiptStore = create<ReceiptState>((set) => ({
       const url = `${API_URL}/receipts?project_id=${projectId}`;
       const response = await axios.get(url, { headers });
       const receiptsData = Array.isArray(response.data) ? response.data : [];
-
       set({ receipts: receiptsData, isLoading: false });
       return receiptsData;
     } catch (error) {
@@ -236,14 +316,12 @@ export const useReceiptStore = create<ReceiptState>((set) => ({
         set({ receipts: [], isLoading: false, error: null });
         return [];
       }
-
       let errorMessage = "Failed to fetch receipts";
       if (axios.isAxiosError(error)) {
         errorMessage = error.response?.data?.message || error.message;
       } else if (error instanceof Error) {
         errorMessage = error.message;
       }
-
       set({
         error: errorMessage,
         isLoading: false,

--- a/Apps/pisowise-fe/components/projects/details/AddReceipt.tsx
+++ b/Apps/pisowise-fe/components/projects/details/AddReceipt.tsx
@@ -1,19 +1,38 @@
 "use client";
 
+import type React from "react";
 import { Button } from "@/components/ui/button";
 import { useModalStore } from "@/app/store/project/modal-store";
-import { Undo2, Image as ImageIcon, Loader, XCircle } from "lucide-react";
+import { useReceiptStore } from "@/app/store/project/receipt-store";
+import { Undo2, ImageIcon, Loader, XCircle } from "lucide-react";
 import { useRef, useState, useEffect } from "react";
 import Image from "next/image";
 
-export default function AddReceipt() {
-  const { closeAddReceiptPage, openManualReceipt } = useModalStore();
-  const fileInputRef = useRef<HTMLInputElement>(null);
+interface AddReceiptProps {
+  project_id: string;
+}
 
-  const [isUploading, setIsUploading] = useState(false);
+export default function AddReceipt({ project_id }: AddReceiptProps) {
+  const { closeAddReceiptPage, openManualReceipt } = useModalStore();
+  const { uploadReceiptWithImage, isUploading, uploadError, clearErrors } =
+    useReceiptStore();
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+
+  // cleanup on unmount, prevent memory leaks
+  useEffect(() => {
+    return () => {
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl);
+      }
+    };
+  }, [previewUrl]);
+
+  // clean errors when component mounts
+  useEffect(() => {
+    clearErrors();
+  }, [clearErrors]);
 
   const handleInputBoxClick = () => {
     if (!isUploading) fileInputRef.current?.click();
@@ -22,44 +41,24 @@ export default function AddReceipt() {
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (file) {
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl);
+      }
       setSelectedFile(file);
       setPreviewUrl(URL.createObjectURL(file));
-      setError(null);
+      clearErrors();
     }
   };
 
   const handleUpload = async () => {
-    if (!selectedFile) return;
-
-    setIsUploading(true);
-    setError(null);
-
-    try {
-      await new Promise((resolve, reject) =>
-        setTimeout(() => {
-          const fail = Math.random() < 0.3;
-          if (fail) {
-            reject(new Error("OCR failed"));
-          } else {
-            resolve("Success");
-          }
-        }, 2000),
-      );
-
-      console.log("File uploaded successfully:", selectedFile.name);
-    } catch (err) {
-      console.error("Upload failed:", err);
-      setError("Can't Read Receipt");
-    } finally {
-      setIsUploading(false);
+    if (!selectedFile) {
+      return;
+    }
+    const result = await uploadReceiptWithImage(selectedFile, project_id);
+    if (result) {
+      closeAddReceiptPage();
     }
   };
-
-  useEffect(() => {
-    return () => {
-      if (previewUrl) URL.revokeObjectURL(previewUrl);
-    };
-  }, [previewUrl]);
 
   return (
     <div className="flex flex-col mt-2">
@@ -76,23 +75,20 @@ export default function AddReceipt() {
           <span className="font-roboto-regular text-[16px]">Back</span>
         </Button>
       </div>
-
       {/* Content */}
       <div className="relative flex flex-col w-full items-center">
         {isUploading && (
           <div className="fixed inset-0 bg-black/30 backdrop-blur-sm z-20" />
         )}
         <div
-          className={`w-full max-w-sm md:max-w-md flex flex-col items-center gap-6 relative z-10 ${
-            isUploading ? "pointer-events-none select-none" : ""
-          }`}
+          className={`w-full max-w-sm md:max-w-md flex flex-col items-center gap-6 relative z-10 ${isUploading ? "pointer-events-none select-none" : ""}`}
         >
-          {error && (
+          {uploadError && (
             <div className="flex justify-center items-center bg-[#1B1212] border-2 border-[#E73648] rounded-[12px] p-4">
               <div className="flex flex-row items-center text-center gap-3">
                 <XCircle className="text-red-400 w-6 h-6" />
                 <span className="text-red-400 font-roboto-regular text-[16px]">
-                  Error! {error}
+                  Error! {uploadError}
                 </span>
               </div>
             </div>
@@ -107,14 +103,12 @@ export default function AddReceipt() {
           />
           <div
             onClick={handleInputBoxClick}
-            className={`flex items-center justify-center bg-[#1B1212] h-[294px] w-full md:w-[640px] md:h-[455px] rounded-[12px] border-2 border-[#349868] transition ${
-              isUploading ? "cursor-not-allowed" : "cursor-pointer"
-            }`}
+            className={`flex items-center justify-center bg-[#1B1212] h-[294px] w-full md:w-[640px] md:h-[455px] rounded-[12px] border-2 border-[#349868] transition ${isUploading ? "cursor-not-allowed" : "cursor-pointer"}`}
           >
             {previewUrl ? (
               <Image
-                src={previewUrl}
-                alt="Preview"
+                src={previewUrl || "/placeholder.svg"}
+                alt="Receipt preview"
                 width={640}
                 height={455}
                 className="max-h-full max-w-full object-contain rounded-[12px] p-2"

--- a/Apps/pisowise-fe/components/receipts/modals/ConfirmationModal.tsx
+++ b/Apps/pisowise-fe/components/receipts/modals/ConfirmationModal.tsx
@@ -27,7 +27,7 @@ export function ConfirmationModal({ receiptId }: ConfirmationModalProps) {
       if (receiptId) {
         await deleteReceipt(receiptId);
         closeConfirmDeleteModal();
-        router.push(`/projects/${receiptId}`);
+        router.push(`/projects/`);
       }
     } catch (error) {
       console.error("Error deleting receipt:", error);

--- a/Apps/pisowise-fe/next.config.ts
+++ b/Apps/pisowise-fe/next.config.ts
@@ -4,7 +4,7 @@ const nextConfig: NextConfig = {
   /* config options here */
   reactStrictMode: true,
   images: {
-    domains: ["i.pinimg.com", "i.ebayimg.com"], // Add external domains here
+    domains: ["i.pinimg.com", "i.ebayimg.com", "pisowise-receipts.s3.ap-southeast-1.amazonaws.com"], // Add external domains here
     remotePatterns: [
       {
         protocol: "https",

--- a/Apps/pisowise-fe/next.config.ts
+++ b/Apps/pisowise-fe/next.config.ts
@@ -4,7 +4,11 @@ const nextConfig: NextConfig = {
   /* config options here */
   reactStrictMode: true,
   images: {
-    domains: ["i.pinimg.com", "i.ebayimg.com", "pisowise-receipts.s3.ap-southeast-1.amazonaws.com"], // Add external domains here
+    domains: [
+      "i.pinimg.com",
+      "i.ebayimg.com",
+      "pisowise-receipts.s3.ap-southeast-1.amazonaws.com",
+    ], // Add external domains here
     remotePatterns: [
       {
         protocol: "https",

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "PisoWise",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "PisoWise",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
- Add S3 upload image endpoint for receipt image storage.
- Add image_url to receipt models to store uploaded image links.
- Add project_id as metadata on submit to associate uploads with a specific project. 
- Integrate upload image and receipt store into the main workflow.