### PR TITLE
Feat/psw 36 be refactor receipt logic to clean architecture

### DIFF
--- a/Apps/pisowise-be/models/receipt.py
+++ b/Apps/pisowise-be/models/receipt.py
@@ -3,6 +3,7 @@ from typing import Optional, List
 from datetime import date
 from models.item import ItemResponse, ItemUpdate
 
+
 class ReceiptCreate(BaseModel):
     project_id: str
     total_amount: float
@@ -10,10 +11,12 @@ class ReceiptCreate(BaseModel):
     vendor_name: Optional[str] = None
     image_url: Optional[str] = None
 
+
 class ReceiptUpdate(BaseModel):
     transaction_date: Optional[date] = None
     vendor_name: Optional[str] = None
     items: Optional[List[ItemUpdate]] = None
+
 
 class ReceiptResponse(BaseModel):
     receipt_id: str
@@ -27,5 +30,7 @@ class ReceiptResponse(BaseModel):
     class Config:
         from_attributes = True
 
+
 class UploadResponse(BaseModel):
-   image_url: str
+    image_url: str
+

--- a/Apps/pisowise-be/repositories/receipt_repository.py
+++ b/Apps/pisowise-be/repositories/receipt_repository.py
@@ -26,9 +26,7 @@ class ReceiptRepository:
         return self.db.query(Receipt).filter(Receipt.receipt_id == receipt_id).first()
 
     def clear_receipt_items(self, receipt_id: str) -> Receipt:
-        receipt = (
-            self.db.query(Receipt).filter(Receipt.receipt_id == receipt_id).first()
-        )
+        receipt = self.db.query(Receipt).filter(Receipt.receipt_id == receipt_id).first()
 
         if not receipt:
             raise ValueError(f"Receipt with id {receipt_id} not found")
@@ -39,7 +37,9 @@ class ReceiptRepository:
         self.db.refresh(receipt)
         return receipt
 
-    def add_item_to_receipt(self, receipt: Receipt, item_data: ReceiptUpdate) -> Receipt:
+    def add_item_to_receipt(
+        self, receipt: Receipt, item_data: ReceiptUpdate
+    ) -> Receipt:
         update_data = item_data.model_dump(exclude_unset=True)
 
         for field, value in update_data.items():
@@ -59,10 +59,7 @@ class ReceiptRepository:
         return receipt
 
     def update_receipt_fields(
-        self, 
-        receipt: ReceiptResponse, 
-        update_data: ReceiptUpdate, 
-        total_amount: float
+        self, receipt: ReceiptResponse, update_data: ReceiptUpdate, total_amount: float
     ) -> ReceiptResponse:
         updateData = update_data.model_dump(exclude_unset=True)
 

--- a/Apps/pisowise-be/repositories/receipt_repository.py
+++ b/Apps/pisowise-be/repositories/receipt_repository.py
@@ -16,7 +16,7 @@ class ReceiptRepository:
         self.db.refresh(receipt)
         return receipt
 
-    def get_all_receipts(self) -> List[ReceiptResponse]:
+    def get_all_receipts(self) -> List[Receipt]:
         return self.db.query(Receipt).all()
 
     def get_receipts_by_project_id(self, project_id: str) -> List[Receipt]:

--- a/Apps/pisowise-be/repositories/receipt_repository.py
+++ b/Apps/pisowise-be/repositories/receipt_repository.py
@@ -26,13 +26,16 @@ class ReceiptRepository:
         return self.db.query(Receipt).filter(Receipt.receipt_id == receipt_id).first()
 
     def clear_receipt_items(self, receipt_id: str) -> Receipt:
-        receipt = self.db.query(Receipt).filter(Receipt.receipt_id == receipt_id).first()
+        receipt = (
+            self.db.query(Receipt).filter(Receipt.receipt_id == receipt_id).first()
+        )
 
         if not receipt:
             raise ValueError(f"Receipt with id {receipt_id} not found")
 
         for item in receipt.items:
             self.db.delete(item)
+
         self.db.commit()
         self.db.refresh(receipt)
         return receipt
@@ -54,6 +57,7 @@ class ReceiptRepository:
                         receipt=receipt,
                     )
                     self.db.add(new_item)
+
         self.db.commit()
         self.db.refresh(receipt)
         return receipt

--- a/Apps/pisowise-be/repositories/receipt_repository.py
+++ b/Apps/pisowise-be/repositories/receipt_repository.py
@@ -1,7 +1,8 @@
 from sqlalchemy.orm import Session
 from models.base import Receipt, Item
-from models.receipt import ReceiptCreate, ReceiptUpdate
+from models.receipt import ReceiptCreate, ReceiptUpdate, ReceiptResponse
 from typing import List
+
 
 class ReceiptRepository:
     def __init__(self, db: Session):
@@ -15,60 +16,75 @@ class ReceiptRepository:
         self.db.refresh(receipt)
         return receipt
 
-    def get_all_receipts(self) -> List[Receipt]:
+    def get_all_receipts(self) -> List[ReceiptResponse]:
         return self.db.query(Receipt).all()
 
     def get_receipts_by_project_id(self, project_id: str) -> List[Receipt]:
         return self.db.query(Receipt).filter(Receipt.project_id == project_id).all()
-    
+
     def get_receipt_by_id(self, receipt_id: str) -> Receipt | None:
         return self.db.query(Receipt).filter(Receipt.receipt_id == receipt_id).first()
 
-    def update_receipt(self, receipt_id: str, updates: ReceiptUpdate) -> Receipt:
-        receipt = self.db.query(Receipt).filter(Receipt.receipt_id == receipt_id).first()
-    
+    def clear_receipt_items(self, receipt_id: str) -> Receipt:
+        receipt = (
+            self.db.query(Receipt).filter(Receipt.receipt_id == receipt_id).first()
+        )
+
         if not receipt:
             raise ValueError(f"Receipt with id {receipt_id} not found")
-    
-        update_data = updates.model_dump(exclude_unset=True)
-    
+
+        for item in receipt.items:
+            self.db.delete(item)
+        self.db.commit()
+        self.db.refresh(receipt)
+        return receipt
+
+    def add_item_to_receipt(self, receipt: Receipt, item_data: ReceiptUpdate) -> Receipt:
+        update_data = item_data.model_dump(exclude_unset=True)
+
         for field, value in update_data.items():
             if field == "items":
-                # Clear existing items
-                for item in receipt.items:
-                    self.db.delete(item)
-                self.db.flush()
-    
-                # Add new items and compute total
-                total_amount = 0
-                for item_data in value:
-                    total_price = item_data["quantity"] * item_data["unit_price"]
-                    total_amount += total_price
-    
+                for itemData in value:
+                    total_price = itemData["quantity"] * itemData["unit_price"]
                     new_item = Item(
-                        item_name=item_data["item_name"],
-                        quantity=item_data["quantity"],
-                        unit_price=item_data["unit_price"],
+                        item_name=itemData["item_name"],
+                        quantity=itemData["quantity"],
+                        unit_price=itemData["unit_price"],
                         total_price=total_price,
-                        receipt=receipt
+                        receipt=receipt,
                     )
                     self.db.add(new_item)
-    
-                receipt.total_amount = total_amount
-            else:
-                setattr(receipt, field, value)
-    
+        self.db.commit()
+        self.db.refresh(receipt)
+        return receipt
+
+    def update_receipt_fields(
+        self, 
+        receipt: ReceiptResponse, 
+        update_data: ReceiptUpdate, 
+        total_amount: float
+    ) -> ReceiptResponse:
+        updateData = update_data.model_dump(exclude_unset=True)
+
+        for field, value in updateData.items():
+            if field == "items":
+                continue
+            setattr(receipt, field, value)
+
+        receipt.total_amount = total_amount
+
         self.db.commit()
         self.db.refresh(receipt)
         return receipt
 
     def delete_receipt(self, receipt_id: str) -> bool:
-        receipt = self.db.query(Receipt).filter(Receipt.receipt_id == receipt_id).first()
+        receipt = (
+            self.db.query(Receipt).filter(Receipt.receipt_id == receipt_id).first()
+        )
         if not receipt:
             return False
-    
+
         self.db.query(Item).filter(Item.receipt_id == receipt_id).delete()
         self.db.delete(receipt)
         self.db.commit()
         return True
-

--- a/Apps/pisowise-be/usecases/receipt_usecase.py
+++ b/Apps/pisowise-be/usecases/receipt_usecase.py
@@ -1,5 +1,6 @@
 import datetime
 from fastapi import HTTPException, UploadFile
+from sqlalchemy import update
 from sqlalchemy.orm import Session
 import os
 import uuid
@@ -7,6 +8,7 @@ from repositories.receipt_repository import ReceiptRepository
 from repositories.s3_repository import S3Repository
 from models.receipt import ReceiptCreate, ReceiptUpdate, ReceiptResponse
 from typing import List, Dict, Union
+
 
 class ReceiptUseCase:
     def __init__(self, db: Session):
@@ -22,7 +24,9 @@ class ReceiptUseCase:
     def get_receipts_by_project_id_usecase(self, project_id: str) -> List[ReceiptResponse]:
         receipts = self.repo.get_receipts_by_project_id(project_id)
         if not receipts:
-            raise HTTPException(status_code=404, detail="No receipts found for this project")
+            raise HTTPException(
+                status_code=404, detail="No receipts found for this project"
+            )
         return receipts
 
     def get_receipt_by_id_usecase(self, receipt_id: str) -> ReceiptResponse:
@@ -34,22 +38,35 @@ class ReceiptUseCase:
         return receipt
 
     def update_receipt_usecase(self, receipt_id: str, updates: ReceiptUpdate) -> ReceiptResponse:
-        return self.repo.update_receipt(receipt_id, updates)
+        receipt = self.repo.get_receipt_by_id(receipt_id)
+
+        self.repo.clear_receipt_items(receipt_id)
+        receipt = self.repo.add_item_to_receipt(receipt, updates)
+
+        total_amount = 0.0 
+        for item in receipt.items:
+            total_amount += item.quantity * item.unit_price
+
+        updated_receipt = self.repo.update_receipt_fields(
+            receipt, updates, total_amount
+        )
+
+        return updated_receipt
 
     def delete_receipt_usecase(self, receipt_id: str) -> bool:
         receipt = self.repo.get_receipt_by_id(receipt_id)
         if receipt and receipt.image_url:
             try:
-                key = receipt.image_url.split('.com/')[1]
+                key = receipt.image_url.split(".com/")[1]
                 self.s3_repo.delete_file(key)
             except Exception:
                 pass
         return self.repo.delete_receipt(receipt_id)
 
     async def upload_receipt_image_usecase(
-        self, 
-        file: UploadFile, 
-        project_id: str, 
+        self,
+        file: UploadFile,
+        project_id: str,
     ) -> Dict[str, Union[str, ReceiptResponse]]:
         try:
             if not file:
@@ -60,16 +77,21 @@ class ReceiptUseCase:
 
             # Generate unique file ID and S3 key
             file_id = str(uuid.uuid4())
-            file_extension = os.path.splitext(file.filename)[1] if file.filename else ".jpg"
+            file_extension = (
+                os.path.splitext(file.filename)[1] if file.filename else ".jpg"
+            )
             s3_key = f"receipts/{file_id}{file_extension}"
 
             image_url = await self.s3_repo.upload_file(
                 file_content=file_content,
                 key=s3_key,
                 content_type=file.content_type or "application/octet-stream",
-                project_id=project_id
+                project_id=project_id,
             )
             return {"image_url": image_url}
 
         except Exception as e:
-            raise HTTPException(status_code=500, detail=f"Image upload failed: {str(e)}")
+            raise HTTPException(
+                status_code=500, detail=f"Image upload failed: {str(e)}"
+            )
+


### PR DESCRIPTION
# Removed Large `update_receipt` function in repository and split into three functions 

### `clear_receipt_items`
<img width="602" height="172" alt="image" src="https://github.com/user-attachments/assets/66c7f50f-1a5d-4647-9d1d-15365352bfa5" />

###  `add_item_to_receipt`
<img width="535" height="305" alt="image" src="https://github.com/user-attachments/assets/65c389f7-3e7d-413f-8967-171d54c0b46f" />

###  `update_receipt_fields`
<img width="593" height="228" alt="image" src="https://github.com/user-attachments/assets/2443811a-e06d-49a4-ab06-039f04332e50" />

# Moved business logic to usecase

### `update_receipt_usecase`

<img width="680" height="231" alt="image" src="https://github.com/user-attachments/assets/84137490-ff02-4024-a49a-c8b889265ca2" />

